### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,13 +18,13 @@ github:
   description: Global-Scale Sustainable Blockchain Fabric
   homepage: https://resilientdb.incubator.apache.org/
   labels:
-    - crypto 
-    - smart-contracts 
-    - blockchain 
-    - solidity 
-    - distributed-database 
-    - key-value-database 
-    - distributed-ledger 
+    - crypto
+    - smart-contracts
+    - blockchain
+    - solidity
+    - distributed-database
+    - key-value-database
+    - distributed-ledger
     - blockchain-platform
     - utxo
   enabled_merge_buttons:
@@ -35,8 +35,21 @@ github:
     main:
       required_status_checks:
         strict: true
-  
+
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@resilientdb.apache.org
-  issues:       commits@resilientdb.apache.org
+  commits: commits@resilientdb.apache.org
+  issues: commits@resilientdb.apache.org
   pullrequests: commits@resilientdb.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
